### PR TITLE
Add documentation and tutorials to most wanted

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 
 [Lists](most-wanted/README-wanted.md) of most wanted
 [core features](most-wanted/features.md),
-[native library bindings](most-wanted/bindings.md), and
-[modules](most-wanted/modules.md) for Perl 6, along with the
+[native library bindings](most-wanted/bindings.md),
+[modules](most-wanted/modules.md) and
+[documentation and tutorials](most-wanted/documentation.md) for Perl 6, along with the
 [research](data-sources/README-sources.md) that helped us select them.
 
 

--- a/most-wanted/README-wanted.md
+++ b/most-wanted/README-wanted.md
@@ -7,3 +7,4 @@ directory.  The files here are broken down as follows:
 * [Core functionality and setting features](features.md)
 * [Native library bindings](bindings.md)
 * [Perl 6 modules](modules.md)
+* [Documentation and tutorials](documentation.md)

--- a/most-wanted/documentation.md
+++ b/most-wanted/documentation.md
@@ -1,0 +1,16 @@
+# Most Wanted Documentation and Tutorials
+
+Sometimes, the documentation (references for operations, function, methods, etc.) 
+does not follow the speed of development. Some features and language constructions
+are poorly documented and need to be addressed in order to reach a wider audience.
+
+
+## Documentation
+
+* [hyper](http://doc.perl6.org/routine/hyper).
+
+
+## Tutorials
+
+* [Grammars](http://doc.perl6.org/language/grammars) (rewrite)
+* [hyper](http://doc.perl6.org/routine/hyper).


### PR DESCRIPTION
The documentation of some important Perl6 feature is lacking or missing. I added this as a new category, so people that want to work on the documentation know where to start.

The PR is meant to get feedback on the desirability of this addition.