### PR TITLE
Add Net::LDAP

### DIFF
--- a/most-wanted/modules.md
+++ b/most-wanted/modules.md
@@ -54,6 +54,8 @@ libraries, but that is not necessarily the case.
     - emit (WIP: [XML::Writer](https://github.com/masak/xml-writer/))
     - full (WIP: [XML](https://github.com/supernovus/exemel/))
   + YAML (WIP: [YAML](https://github.com/ingydotnet/yaml-pm6/))
+  + LDIF
+      - Net::LDAP port
 * Binary interchange of structured data
   + BSON (WIP: [BSON](https://github.com/bbkr/BSON/))
 * Web markup
@@ -101,6 +103,8 @@ libraries, but that is not necessarily the case.
   + Memcached (WIP: [Cache::Memcached](https://github.com/cosimo/perl6-cache-memcached/))
   + CouchDB (WIP: [CouchDB](https://github.com/jonathanstowe/CouchDB))
 * CHI, Cache::Cache, or similar
+* LDAP
+  + Net::LDAP port?
 
 
 ## Development


### PR DESCRIPTION
Thanks to perl-ldap (https://github.com/perl-ldap/perl-ldap, https://metacpan.org/pod/distribution/perl-ldap/lib/Net/LDAP.pod), perl5 is a very popular language for LDAP related code. A port of this venerable module is very desirable, imho.