### PR TITLE
Add WIP for Crypt::Random

### DIFF
--- a/most-wanted/modules.md
+++ b/most-wanted/modules.md
@@ -38,7 +38,7 @@ libraries, but that is not necessarily the case.
   + Full set of block cypher modes
 * RNG
   + MT (Mersenne Twister) (WIP: [Math::Random](https://github.com/bluebear94/Math-Random))
-  + TrulyRandom (portable access to OS-provided truly random sources) (WIP: [Math::TrulyRandom](https://github.com/sevvie/math-trulyrandom))
+  + TrulyRandom (portable access to OS-provided truly random sources) (WIP: [Math::TrulyRandom](https://github.com/sevvie/math-trulyrandom), [Crypt::Random](https://github.com/skinkade/crypt-random))
 
 
 ## Data formats


### PR DESCRIPTION
Emulates the functionality of `arc4random()`, using OpenBSD sources for reference and Windows support.

In its current state, draws bytes from `/dev/urandom` on Unix-like systems and `CryptGenRandom()` on Windows. The bundled shared library for Windows is untested.