### PR TITLE
Remove TrulyRandom from Most Wanted

### DIFF
--- a/most-wanted/modules.md
+++ b/most-wanted/modules.md
@@ -38,7 +38,6 @@ libraries, but that is not necessarily the case.
   + Full set of block cypher modes
 * RNG
   + MT (Mersenne Twister) (WIP: [Math::Random](https://github.com/bluebear94/Math-Random))
-  + TrulyRandom (portable access to OS-provided truly random sources) (WIP: [Math::TrulyRandom](https://github.com/sevvie/math-trulyrandom), [Crypt::Random](https://github.com/skinkade/crypt-random))
 
 
 ## Data formats


### PR DESCRIPTION
Crypt::Random is now complete and listed in the main modules directory.