### PR TITLE
Add "NLP and Machine Learning" section to the list

### DIFF
--- a/most-wanted/bindings.md
+++ b/most-wanted/bindings.md
@@ -31,13 +31,21 @@ better spent on [other most-wanted tasks](README-wanted.md).
 * ImageMagick or similar (WIP: [MagickWand](https://github.com/azawawi/perl6-magickwand))
 
 
-## i18n and NLP
+## i18n and Text processing
 
-Internationalization and Natural Language Processing
+Internationalization and Text processing
 
 * [ICU](http://site.icu-project.org/)
 * [Snowball](http://snowball.tartarus.org/) (WIP: [perl6-snowball](https://github.com/Sufrostico/perl6-snowball) )
 
+## NLP and Machine Learning
+
+Natural Language Processing and Machine Learning
+
+* [LIBSVM](https://github.com/cjlin1/libsvm)
+* [LIBLINEAR](https://github.com/cjlin1/liblinear)
+* [XGBoost](https://github.com/dmlc/xgboost)
+* [MeCab](http://mecab.googlecode.com/svn/trunk/mecab/doc/index.html)
 
 ## Security
 


### PR DESCRIPTION
I changed the section name **i18n and NLP** to **i18n and Text processing**, because **NLP** does not seem to be proper naming for just stemming or normalization.
Moreover, I added **NLP and Machine Learning** section to the list, since competing languages such as python have many bindings for NLP and Machine Learning.