### PR TITLE
Remove Devel::Trace since we already have one

### DIFF
--- a/most-wanted/modules.md
+++ b/most-wanted/modules.md
@@ -126,7 +126,6 @@ libraries, but that is not necessarily the case.
   + Devel::FindRef
   + Devel::PartialDump
 * Tracing
-  + Devel::Trace
   + Devel::STDERR::Indent
 * Profiling
   + Grammars (WIP: [Grammar::Profiler::Simple](https://github.com/perlpilot/Grammar-Profiler-Simple/))


### PR DESCRIPTION
See https://github.com/Altai-man/perl6-Devel-Trace